### PR TITLE
Add script to fetch trending hashtags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ story](https://www.jitbit.com/alexblog/249-now-thats-what-i-call-a-hacker/)_:
 
 > xxx: (and the oscar goes to) [`fucking-coffee.sh`](https://github.com/NARKOZ/hacker-scripts/blob/master/fucking-coffee.sh) - this one waits exactly 17 seconds (!), then opens a telnet session to our coffee-machine (we had no frikin idea the coffee machine is on the network, runs linux and has a TCP socket up and running) and sends something like `sys brew`. Turns out this thing starts brewing a mid-sized half-caf latte and waits another 24 (!) seconds before pouring it into a cup. The timing is exactly how long it takes to walk to the machine from the dudes desk.
 
+> xxx: [`trending_hashtags.py`](https://github.com/NARKOZ/hacker-scripts/blob/master/python/trending_hashtags.py) - prints the current trending hashtags on Twitter using the API.
+
 > xxx: holy sh*t I'm keeping those
 
 Original: http://bash.im/quote/436725 (in Russian)  
@@ -34,10 +36,19 @@ TWILIO_AUTH_TOKEN=yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
 # used in `kumar_asshole` script
 GMAIL_USERNAME=admin@example.org
 GMAIL_PASSWORD=password
+
+# used in `trending_hashtags` script
+TWITTER_CONSUMER_KEY=xxxxxxxxxxxxxxxxxxxx
+TWITTER_CONSUMER_SECRET=xxxxxxxxxxxxxxxxxxxx
+TWITTER_ACCESS_TOKEN=xxxxxxxxxxxxxxxxxxxx
+TWITTER_ACCESS_SECRET=xxxxxxxxxxxxxxxxxxxx
 ```
 
 For Ruby scripts you need to install gems:
 `gem install dotenv twilio-ruby gmail`
+
+For the Twitter script you need to install Tweepy:
+`pip install tweepy`
 
 ## Cron jobs
 

--- a/python/trending_hashtags.py
+++ b/python/trending_hashtags.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+import os
+import tweepy
+
+# Twitter API credentials
+CONSUMER_KEY = os.environ.get('TWITTER_CONSUMER_KEY')
+CONSUMER_SECRET = os.environ.get('TWITTER_CONSUMER_SECRET')
+ACCESS_TOKEN = os.environ.get('TWITTER_ACCESS_TOKEN')
+ACCESS_SECRET = os.environ.get('TWITTER_ACCESS_SECRET')
+
+if not all([CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_SECRET]):
+    raise SystemExit("Twitter API credentials are not set")
+
+auth = tweepy.OAuthHandler(CONSUMER_KEY, CONSUMER_SECRET)
+auth.set_access_token(ACCESS_TOKEN, ACCESS_SECRET)
+api = tweepy.API(auth)
+
+# Worldwide WOEID
+WOEID = 1
+trends = api.trends_place(WOEID)
+
+for trend in trends[0]['trends']:
+    print(trend['name'])


### PR DESCRIPTION
## Summary
- add `trending_hashtags.py` to fetch trending hashtags via the Twitter API
- document Twitter API environment vars and Tweepy dependency in README
- mention the new script in README intro

## Testing
- `python -m py_compile python/trending_hashtags.py`


------
https://chatgpt.com/codex/tasks/task_e_683f979a6a6c8320b30fdd61e17c18f0